### PR TITLE
Task 2-5 solution

### DIFF
--- a/src/main/kotlin/lesson_2/lesson2_task5.kt
+++ b/src/main/kotlin/lesson_2/lesson2_task5.kt
@@ -1,0 +1,17 @@
+package org.example.lesson_2
+
+import kotlin.math.pow
+
+fun main() {
+    val initialDeposit = 70_000
+    val interestRate = 16.7
+    val depositTerm = 20
+
+    val depositFinal = (initialDeposit * (1 + (interestRate / 100)).pow(depositTerm))
+
+    println("Начальный размер вклада: ${initialDeposit} руб.")
+    println("Годовая процентная ставка: ${interestRate}%")
+    println("Срок вклада, полных лет: ${depositTerm}")
+    //  если не обращать внимания на формат десятичного разделителя, то вывод соответствует условию
+    println("К концу срока вклада сумма будет равна: " + "%.3f".format(depositFinal) + " руб.")
+}

--- a/src/main/kotlin/lesson_2/lesson2_task5.kt
+++ b/src/main/kotlin/lesson_2/lesson2_task5.kt
@@ -9,9 +9,9 @@ fun main() {
 
     val depositFinal = (initialDeposit * (1 + (interestRate / 100)).pow(depositTerm))
 
-    println("Начальный размер вклада: ${initialDeposit} руб.")
-    println("Годовая процентная ставка: ${interestRate}%")
-    println("Срок вклада, полных лет: ${depositTerm}")
+    println("Начальный размер вклада: $initialDeposit руб.")
+    println("Годовая процентная ставка: $interestRate%")
+    println("Срок вклада, полных лет: $depositTerm")
     //  если не обращать внимания на формат десятичного разделителя, то вывод соответствует условию
-    println("К концу срока вклада сумма будет равна: " + "%.3f".format(depositFinal) + " руб.")
+    println("К концу срока вклада сумма будет равна: ${"%.3f".format(depositFinal)} руб.")
 }


### PR DESCRIPTION
Подскажи, пожалуйста, такой вот момент про интерполяцию:

1    println("Начальный размер вклада: ${initialDeposit} руб.")
2    println("Годовая процентная ставка: ${interestRate}%")
3    println("Срок вклада, полных лет: ${depositTerm}")

IDEA утверждает, что в строках 1 и 3 фигурные скобки, обрамляющие интерполируемые переменные не нужны. Гугл говорит, что они нужны, если {внутри проводятся вычисления}. Почему тогда не рекомендует убирать во второй строке?
